### PR TITLE
Add agenttrace to open-source AgentOps tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ AgentOps platforms are instrumented via **OpenTelemetry**, where each agent sess
 | Open Bias | ⭐ 89 | https://github.com/open-bias/open-bias |
 | KubeStellar | ⭐ 84 | https://github.com/kubestellar/console |
 | Dunetrace | ⭐ 42 | https://github.com/dunetrace/dunetrace |
+| agenttrace | ⭐ 32 | https://github.com/luoyuctl/agenttrace |
 <!-- OSS_TABLE:END -->
 
 Stars updated daily via GitHub Actions.

--- a/data/tools.json
+++ b/data/tools.json
@@ -132,6 +132,17 @@
     "display_link": "https://github.com/raga-ai-hub/RagaAI-Catalyst"
   },
   {
+    "name": "agenttrace",
+    "category": "open_source",
+    "focus": "Local coding-agent session replay, diffing & audit",
+    "official_url": "https://github.com/luoyuctl/agenttrace",
+    "github_repo": "luoyuctl/agenttrace",
+    "docs_url": "https://github.com/luoyuctl/agenttrace#readme",
+    "pricing_label": "",
+    "pricing_url": "",
+    "display_link": "https://github.com/luoyuctl/agenttrace"
+  },
+  {
     "name": "DeepEval",
     "category": "open_source",
     "focus": "LLM & agent evaluation (50+ metrics)",


### PR DESCRIPTION
Adds agenttrace as an open-source local observability/debugging tool for coding-agent sessions. The entry points to the GitHub repo and README, and the generated OSS table includes the current star count.