### PR TITLE
Add APort to AgentOps landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,10 +136,11 @@ AgentOps platforms are instrumented via **OpenTelemetry**, where each agent sess
 | Weave (W&B) | ⭐ 1.1k | https://github.com/wandb/weave |
 | Agent Evaluation (AWS Labs) | ⭐ 361 | https://github.com/awslabs/agent-evaluation |
 | Monocle2AI | ⭐ 123 | https://github.com/monocle2ai/monocle |
-| Open Bias | ⭐ 115 | https://github.com/open-bias/open-bias |
+| Open Bias | ⭐ 116 | https://github.com/open-bias/open-bias |
 | KubeStellar | ⭐ 100 | https://github.com/kubestellar/console |
 | Dunetrace | ⭐ 44 | https://github.com/dunetrace/dunetrace |
 | agenttrace | ⭐ 35 | https://github.com/luoyuctl/agenttrace |
+| APort | ⭐ 4 | https://github.com/aporthq/aport-integrations |
 | agentcheck | ⭐ 0 | https://github.com/paprika-org/agentcheck |
 | agent-bill-guard | ⭐ 0 | https://github.com/paprika-org/agent-bill-guard |
 <!-- OSS_TABLE:END -->

--- a/data/tools.json
+++ b/data/tools.json
@@ -504,5 +504,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/paprika-org/agent-bill-guard"
+},
+{
+  "name": "APort",
+  "category": "open_source",
+  "focus": "Runtime trust rail and integration toolkit for AI agents",
+  "official_url": "https://aport.io/",
+  "github_repo": "aporthq/aport-integrations",
+  "docs_url": "https://github.com/aporthq/aport-integrations#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/aporthq/aport-integrations"
 }
 ]


### PR DESCRIPTION
## Issue
Related bounty: https://github.com/aporthq/aport-integrations/issues/19

## Summary
- Adds APort to `data/tools.json` as an open-source AgentOps/runtime trust rail for AI agents.
- Regenerates `README.md` with the repository's `scripts/update_readme.py` flow so the generated Open Source Tools table stays consistent.

## Verification
- `python -m json.tool data/tools.json`
- `python scripts/update_readme.py`
- `git diff --check`
- Link checks: `https://aport.io/` -> 200, `https://github.com/aporthq/aport-integrations` -> 200

## Bounty / payout
APort bounty issue: https://github.com/aporthq/aport-integrations/issues/19

Preferred payout: PayPal https://paypal.me/Jeremytsangchina
Backup payout: USDT TRC20 `TWupTAoFjxR2VmqUUvzhfmUwXVZR6Kvz1Y`