### PR TITLE
Add ax AgentOps tool entry

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -559,5 +559,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/future-agi/future-agi"
+},
+{
+  "name": "ax",
+  "category": "open_source",
+  "focus": "Local coding-agent telemetry and recall across sessions, tools, skills, and costs",
+  "official_url": "https://github.com/Necmttn/ax",
+  "github_repo": "Necmttn/ax",
+  "docs_url": "https://github.com/Necmttn/ax#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/Necmttn/ax"
 }
 ]


### PR DESCRIPTION
Adds ax to `data/tools.json` as an open-source AgentOps tool.

This is data-only so the repo's daily README generator can update the table and star count.

Checks:
- JSON parse
- focused duplicate/value check
- `git diff --check`
- ax repository link check returned 200
- Subagent fit/spec review and copy review passed

---
_Generated with [ax](https://github.com/Necmttn/ax)._
