### PR TITLE
feat: add OpenClaw Monitor to Open Source Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ AgentOps platforms are instrumented via **OpenTelemetry**, where each agent sess
 | Monocle2AI | ⭐ 114 | https://github.com/monocle2ai/monocle |
 | Open Bias | ⭐ 108 | https://github.com/open-bias/open-bias |
 | KubeStellar | ⭐ 97 | https://github.com/kubestellar/console |
+| [OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) | ⭐ 10 | https://github.com/flik2002/openclaw-monitor |
 | Dunetrace | ⭐ 43 | https://github.com/dunetrace/dunetrace |
 <!-- OSS_TABLE:END -->
 


### PR DESCRIPTION
## OpenClaw Monitor

[OpenClaw Monitor](https://github.com/flik2002/openclaw-monitor) is a free open-source monitoring dashboard for OpenClaw AI agents — token usage, session tracking, 7-day trends, and multi-model support.

### Why this fits

- **Open Source**: Full MIT license, self-hosted
- **OpenClaw-specific**: Only open-source dashboard built specifically for OpenClaw agents
- **Production-ready**: v1.0.0 with GitHub Actions CI/CD
- **Multi-model**: Supports tracking across different models

### Dashboard Preview

![OpenClaw Monitor](https://raw.githubusercontent.com/flik2002/openclaw-monitor/main/Openclaw%20Monitor.jpg)

---

Tools: OpenClaw, AI Agent Monitoring, Dashboard, Vue 3, ECharts
