### PR TITLE
Add whatbroke to tools.json

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -570,5 +570,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/Necmttn/ax"
+},
+{
+  "name": "whatbroke",
+  "category": "open_source",
+  "focus": "Diff agent behavior between two runs: tool calls, args, cost, latency, outcome flips",
+  "official_url": "https://github.com/arthi-arumugam-git/whatbroke",
+  "github_repo": "arthi-arumugam-git/whatbroke",
+  "docs_url": "https://github.com/arthi-arumugam-git/whatbroke#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/arthi-arumugam-git/whatbroke"
 }
 ]


### PR DESCRIPTION
Appends whatbroke to data/tools.json for the pipeline to pick up. It's a CLI I built that diffs two agent runs and reports what changed: tool calls, order, args, cost, latency, and outcome flips, with flake detection across repeats. Fits the evaluation and regression side of the landscape. Open source, MIT, TypeScript, on npm as whatbroke-cli.