### PR TITLE
Add ClawBench to open-source evaluation tools

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -581,5 +581,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/arthi-arumugam-git/whatbroke"
+},
+{
+  "name": "ClawBench",
+  "category": "open_source",
+  "focus": "Web-agent evaluation with isolated runs and synchronized browser actions, screenshots, HTTP traffic, video, and agent messages",
+  "official_url": "https://claw-bench.com/",
+  "github_repo": "TIGER-AI-Lab/ClawBench",
+  "docs_url": "https://github.com/TIGER-AI-Lab/ClawBench#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/TIGER-AI-Lab/ClawBench"
 }
 ]


### PR DESCRIPTION
## Summary

Adds one structured ClawBench record to `data/tools.json`, the repository's documented source for open-source AgentOps tools.

ClawBench evaluates AI web agents in isolated runs and records synchronized browser actions, screenshots, HTTP traffic, video, and agent messages. That makes it relevant to the landscape's evaluation and tracing scope without claiming that it is a production monitoring service.

Primary sources: [project](https://claw-bench.com/), [paper](https://arxiv.org/abs/2604.08523), [code](https://github.com/TIGER-AI-Lab/ClawBench).

## Validation

- `jq` validates `data/tools.json`.
- Confirmed exactly one ClawBench record and all documented fields are present.
- Verified all primary links return HTTP 200.
- `git diff --check` passes.

## Disclosure

I am a ClawBench maintainer and am submitting this entry transparently for maintainer review.
