### PR TITLE
Add telemetry.dev to paid/SaaS tools

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -592,5 +592,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/TIGER-AI-Lab/ClawBench"
-}
+},
+  {
+    "name": "telemetry.dev",
+    "category": "paid",
+    "focus": "OpenTelemetry-native tracing for LLM/agent apps; per-span tokens, cost & latency",
+    "official_url": "https://telemetry.dev/",
+    "github_repo": "",
+    "docs_url": "https://telemetry.dev",
+    "pricing_label": "Free tier (10K spans/mo)",
+    "pricing_url": "https://telemetry.dev/pricing",
+    "display_link": "https://telemetry.dev"
+  }
 ]


### PR DESCRIPTION
Adds one entry to `data/tools.json` in the `paid` category.

**telemetry.dev** — observability for LLM and agent apps. OpenTelemetry-native: any OTLP/HTTP exporter can send to its endpoint, and it follows the OTel GenAI semantic conventions. Captures per-span tokens, cost (computed server-side from real token usage), latency and errors. First-party TypeScript SDKs on npm (`@telemetry-dev/sdk`, `@telemetry-dev/ai-sdk` for the Vercel AI SDK, `@telemetry-dev/otel`); LangChain/Python works over plain OTLP.

Commercial SaaS with a free tier (10K spans/month), so `pricing_label` follows the existing freemium precedent in this list (Portkey `Free tier + usage-based`, Vellum `Free (Pro: $25/mo)`).

Notes:
- Only `data/tools.json` is touched — the README tables are generated from it by `.github/workflows/update-readme.yml`, so editing README.md would just be overwritten on the next run.
- Field set, key order and value style match the neighbouring `paid` entries (e.g. HoneyHive, LangSmith); `github_repo` is `""` as with other paid tools that have no public repo.
- `pricing_label` omits the 💰 emoji because `scripts/update_readme.py` prepends it.
- `docs_url` points at the site root: there is no separate docs host yet (`/docs` currently 404s), so this avoids a dead link in the generated table.
- `jq . data/tools.json` passes.

Disclosure: I'm the author of telemetry.dev.