### PR TITLE
Add SourceryKit to data/tools.json

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -592,5 +592,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/TIGER-AI-Lab/ClawBench"
+},
+{
+  "name": "SourceryKit",
+  "category": "paid",
+  "focus": "Verifies an agent's outbound HTTP and MCP calls against a source of truth using zero-knowledge proofs, then blocks anything off the trusted-endpoint allow-list and logs each call",
+  "official_url": "https://github.com/ProvablyAI/sourcerykit",
+  "github_repo": "ProvablyAI/sourcerykit",
+  "docs_url": "https://github.com/ProvablyAI/sourcerykit#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/ProvablyAI/sourcerykit"
 }
 ]


### PR DESCRIPTION
Hi, nice landscape, the guardrails coverage is handy. Added SourceryKit to data/tools.json.

It's a Python SDK that verifies an agent's outbound HTTP and MCP calls against a source of truth using zero-knowledge proofs, so a call only goes out if the agent's claims check out. It blocks anything off the trusted-endpoint allow-list and logs each call. The SDK is source-available (BSL 1.1) and the ZK/source-of-truth check runs on a hosted backend, so I tagged it 'paid'.

Edited the data file, not the generated README. Thanks for taking a look.