### PR TITLE
Add Flowlines

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -614,5 +614,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/ProvablyAI/sourcerykit"
+},
+{
+  "name": "Flowlines",
+  "category": "paid",
+  "focus": "Behavioral observability for production AI agents; detects drift, context loss, repeated failures, and false success",
+  "official_url": "https://flowlines.ai/",
+  "github_repo": "",
+  "docs_url": "https://flowlines.ai/questions",
+  "pricing_label": "Free during early access",
+  "pricing_url": "https://flowlines.ai/request-access",
+  "display_link": "https://flowlines.ai/"
 }
 ]


### PR DESCRIPTION
## Summary

- Add Flowlines to `data/tools.json` as a paid AgentOps tool.
- Include the required product, documentation, pricing, and display fields.

## Why

Flowlines provides behavioral observability for production AI agents, including drift, context loss, repeated-failure, and false-success detection.

Disclosure: this submission is from the Flowlines team.

## Impact

The scheduled README generator will include Flowlines in the Paid / SaaS Tools table. The generated README is intentionally unchanged in this pull request.

## Validation

- Validated `data/tools.json` with `jq`
- Verified the paid-table generator renders the Flowlines row
- `git diff --check`
- Verified the Flowlines product, questions, and request-access pages return HTTP 200
