### PR TITLE
Add RewardHarness to AgentOps tools data

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -614,5 +614,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/ProvablyAI/sourcerykit"
+},
+{
+  "name": "RewardHarness",
+  "category": "open_source",
+  "focus": "Image-editing preference evaluation with a self-evolving library of scoring skills and tools",
+  "official_url": "https://rewardharness.com/",
+  "github_repo": "TIGER-AI-Lab/RewardHarness",
+  "docs_url": "https://github.com/TIGER-AI-Lab/RewardHarness#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/TIGER-AI-Lab/RewardHarness"
 }
 ]


### PR DESCRIPTION
Adds RewardHarness as an open-source evaluation tool in `data/tools.json`, the repository’s documented source of truth. The scheduled generator can place it by live star count without a hand-edited generated table. JSON parsing and `git diff --check` pass.

Before adding the entry, I searched the default branch and complete issue/PR history for the title, arXiv `2605.08703`, official project URL, and canonical repository; no prior entry or submission was present.

I am submitting this on behalf of paper co-author and repository maintainer Yuxuan Zhang.