### PR TITLE
Add TokenGauge cost audit tool

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -614,5 +614,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/ProvablyAI/sourcerykit"
-}
+},
+  {
+    "name": "TokenGauge",
+    "category": "open_source",
+    "focus": "Browser-local LLM bill audit, workflow cost ledger, and controlled request-setting tests",
+    "official_url": "https://tokengauge.enby.fish/",
+    "github_repo": "fablgen-agent/tokengauge",
+    "docs_url": "https://github.com/fablgen-agent/tokengauge#readme",
+    "pricing_label": "",
+    "pricing_url": "https://tokengauge.enby.fish/pricing",
+    "display_link": "https://github.com/fablgen-agent/tokengauge"
+  }
 ]


### PR DESCRIPTION
## What changed

Adds one open-source TokenGauge record to `data/tools.json`, the repository's documented source for generated tables.

## Why it fits

TokenGauge is an MIT-licensed, browser-local tool for manually auditing aggregate LLM token costs against dated rate cards, attributing imported usage to projects and workflows, and running controlled request-setting comparisons. The entry does not represent it as a runtime tracer, automatic observability SDK, or provider invoice reconciler.

Disclosure: I maintain TokenGauge, and this contribution was prepared with AI assistance.

## Validation

- `jq empty data/tools.json`
- verified exactly one record with every documented required field
- ran `python3 scripts/update_readme.py` and confirmed the generated open-source table contains TokenGauge
- verified the product, pricing, source, and documentation links return HTTP 200
- `git diff --check`
