### PR TITLE
Add XiuRouter to paid tools

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -473,6 +473,17 @@
     "display_link": "https://portkey.ai"
   },
   {
+    "name": "XiuRouter",
+    "category": "paid",
+    "focus": "Multi-model API gateway with request-level token, cost and status records",
+    "official_url": "https://router.xiu.ai/",
+    "github_repo": "",
+    "docs_url": "https://docs.xiu.ai/en/router/",
+    "pricing_label": "Usage-based",
+    "pricing_url": "https://router.xiu.ai/en/pricing",
+    "display_link": "https://router.xiu.ai/"
+  },
+  {
     "name": "KubeStellar",
     "category": "open_source",
     "focus": "AI-powered multi-cluster K8s orchestration & agentic dashboard",


### PR DESCRIPTION
Adds XiuRouter to the paid/SaaS tools data source.

XiuRouter is listed narrowly as a hosted multi-model API gateway with request-level token usage, cost, and status records. It is not presented as a tracing or evaluation platform.

Validation:
- `python3 -m json.tool data/tools.json`
- Confirmed the XiuRouter name and official URL each occur exactly once
- `python3 scripts/update_readme.py` generated the expected `XiuRouter | Usage-based | https://router.xiu.ai/` Paid / SaaS row on August 30, 2026
- Restored the generated `README.md`, so this PR still changes only `data/tools.json`
- Product, docs, and pricing URLs returned HTTP 200 on August 30, 2026
- `git diff --check`

The repository's current paid-tools table only renders name, pricing, and link; the more specific gateway/cost-control description remains in the structured data source.

Disclosure: I am submitting this on behalf of XiuLab Inc, the operator of XiuRouter.
