### PR TITLE
Add SandBase Harness to AgentOps landscape

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,8 @@ AgentOps platforms are instrumented via **OpenTelemetry**, where each agent sess
 | OpenLIT | ⭐ 2.7k | https://github.com/openlit/openlit |
 | Future AGI | ⭐ 1.9k | https://github.com/future-agi/future-agi |
 | Weave (W&B) | ⭐ 1.1k | https://github.com/wandb/weave |
-| ClawBench | ⭐ 608 | https://github.com/TIGER-AI-Lab/ClawBench |
+| SandBase Harness | ⭐ 638 | https://github.com/sandbaseai/sandbase-harness |
+| ClawBench | ⭐ 609 | https://github.com/TIGER-AI-Lab/ClawBench |
 | Agent Evaluation (AWS Labs) | ⭐ 371 | https://github.com/awslabs/agent-evaluation |
 | Monocle2AI | ⭐ 337 | https://github.com/monocle2ai/monocle |
 | traceAI | ⭐ 218 | https://github.com/future-agi/traceAI |

--- a/data/tools.json
+++ b/data/tools.json
@@ -594,7 +594,18 @@
   "display_link": "https://github.com/TIGER-AI-Lab/ClawBench"
 },
   {
-    "name": "telemetry.dev",
+  "name": "SandBase Harness",
+  "category": "open_source",
+  "focus": "Local-first agent runtime with sandboxed sessions, MCP governance, credentials, audit & replay",
+  "official_url": "https://github.com/sandbaseai/sandbase-harness",
+  "github_repo": "sandbaseai/sandbase-harness",
+  "docs_url": "https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/sandbaseai/sandbase-harness"
+},
+  {
+  "name": "telemetry.dev",
     "category": "paid",
     "focus": "OpenTelemetry-native tracing for LLM/agent apps; per-span tokens, cost & latency",
     "official_url": "https://telemetry.dev/",


### PR DESCRIPTION
## Summary
- add SandBase Harness to `data/tools.json` as an open-source AgentOps/runtime tool
- regenerate the daily README table from the repository's updater
- describe sandboxed sessions, MCP governance, credentials, and audit/replay without overstating isolation

Evidence:
- Repository: https://github.com/sandbaseai/sandbase-harness
- Installation guide: https://github.com/sandbaseai/sandbase-harness/blob/main/docs/installation.md
- Latest release: https://github.com/sandbaseai/sandbase-harness/releases/tag/v0.3.8
- License: https://github.com/sandbaseai/sandbase-harness/blob/main/LICENSE

Validation:
- `python3 -m json.tool data/tools.json`
- `python3 scripts/update_readme.py`
- `git diff --check`
