### PR TITLE
docs: add Bifrost to AgentOps catalog

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -614,5 +614,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/ProvablyAI/sourcerykit"
+},
+{
+  "name": "Bifrost",
+  "category": "open_source",
+  "focus": "AI gateway with multi-provider routing, failover, guardrails, MCP gateway support, and observability",
+  "official_url": "https://www.getmaxim.ai/bifrost",
+  "github_repo": "maximhq/bifrost",
+  "docs_url": "https://docs.getbifrost.ai/",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/maximhq/bifrost"
 }
 ]


### PR DESCRIPTION
## Summary

- add Bifrost as an open-source gateway and routing entry in data/tools.json
- let the existing generator update the rendered README tables and metadata