### PR TITLE
Add agent-watch to AgentOps catalog

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -669,5 +669,16 @@
   "pricing_label": "Free during early access",
   "pricing_url": "https://flowlines.ai/request-access",
   "display_link": "https://flowlines.ai/"
+},
+{
+  "name": "agent-watch",
+  "category": "open_source",
+  "focus": "Background coding-agent state and transport preflight",
+  "official_url": "https://github.com/soul-sol/agent-watch",
+  "github_repo": "soul-sol/agent-watch",
+  "docs_url": "https://github.com/soul-sol/agent-watch#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/soul-sol/agent-watch"
 }
 ]


### PR DESCRIPTION
## Summary

- Add [agent-watch](https://github.com/soul-sol/agent-watch) as an open-source AgentOps tool in `data/tools.json`.
- Describe its focused role as background coding-agent state classification and transport preflight.
- Leave README generation and star-based ordering to the repository's existing pipeline.

Agent-watch monitors Claude Code and Codex CLI jobs from process state, recorded exit codes, and log-tail evidence. Version 0.3.0 checks transport before credentials so DNS or API availability failures are not mislabeled as authentication failures.

I maintain agent-watch and am disclosing that affiliation.

## Validation

- `python3 -m json.tool data/tools.json`
- `python3 -m py_compile scripts/update_readme.py`
- Confirmed exactly one `soul-sol/agent-watch` catalog object is present
- `git diff --check`
