### PR TITLE
Add YYLO Benchmark to AgentOps tools data

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -680,5 +680,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/soul-sol/agent-watch"
+},
+{
+  "name": "YYLO Benchmark",
+  "category": "open_source",
+  "focus": "Isolated evaluation layer for agent runs: fresh-repository workspaces, deterministic and/or LLM evaluation profiles, and hash-linked receipts, manifests, and provenance as immutable evidence",
+  "official_url": "https://github.com/yylo-dev/yylo-benchmark",
+  "github_repo": "yylo-dev/yylo-benchmark",
+  "docs_url": "https://github.com/yylo-dev/yylo-benchmark#readme",
+  "pricing_label": "",
+  "pricing_url": "",
+  "display_link": "https://github.com/yylo-dev/yylo-benchmark"
 }
 ]


### PR DESCRIPTION
Adds YYLO Benchmark as an open-source evaluation tool in `data/tools.json`, the repository's documented source of truth. The scheduled generator can place it by live star count without a hand-edited generated table — I ran `scripts/update_readme.py` locally against this change and it renders `| YYLO Benchmark | ⭐ 1 | https://github.com/yylo-dev/yylo-benchmark |` in the Open Source table. `python3 -m json.tool` and `git diff --check` pass.

Before adding the entry, I searched the default branch for the tool name and canonical repository (`yylo-dev/yylo-benchmark`); no prior entry or submission was present.

Why it fits the AgentOps landscape: YYLO Benchmark is an isolated evaluation layer for agent runs — it normalizes every case into one v2 attempt contract, runs each candidate in a private fresh-repository workspace behind a selective filesystem sandbox, and evaluates retained evidence with ordered deterministic and/or LLM profiles. Results are anchored by hash-linked receipts, manifests, and provenance (immutable evidence: initial workspace receipt plus post-execution repository manifest hashes linked through terminal, evidence, and state), which sits naturally beside the evaluation and evidence tools already in the catalog (ClawBench, RewardHarness, agenttrace, Phoenix, DeepEval).

Qualification notes: MIT-licensed, created 2026-08-17, pushed daily; installable via npm as `@yylo/benchmark` (151 downloads in the last month; the parent `@yylo/cli` package does 563/month and the CLI repo holds 57 stars). Every phrase in the `focus` line is quoted or compressed from the live repository README/About.

Disclosure: I am on the team that builds YYLO, and this PR was prepared with an AI coding agent and reviewed by me before submission.
