### PR TITLE
Add Failproof to tools.json

### DIFF
--- a/data/tools.json
+++ b/data/tools.json
@@ -691,5 +691,16 @@
   "pricing_label": "",
   "pricing_url": "",
   "display_link": "https://github.com/yylo-dev/yylo-benchmark"
+},
+{
+  "name": "Failproof",
+  "category": "paid",
+  "focus": "Find failures and prevent them in your agents with policies",
+  "official_url": "https://befailproof.ai",
+  "github_repo": "FailproofAI/failproofai",
+  "docs_url": "https://docs.befailproof.ai",
+  "pricing_label": "Free tier (5K runs/month)",
+  "pricing_url": "https://befailproof.ai/pricing/",
+  "display_link": "https://github.com/FailproofAI/failproofai"
 }
 ]


### PR DESCRIPTION
## What

Adds [Failproof](https://befailproof.ai) to `data/tools.json`, following CONTRIBUTING.md's "Adding a tool" instructions (appending an entry with all required fields; the README tables regenerate from this file on the next scheduled run).

## Why

Failproof is a runtime reliability layer for AI agents (Claude Code, Codex, Cursor, Copilot, Gemini CLI, OpenCode, Goose, LangGraph, and more): it enforces policies at runtime with a full audit trail of every prompt and tool call, so agents can be steered away from unwanted trajectories and outputs. Listed as `"category": "paid"` since the hosted product has a free tier plus paid usage, per the schema's guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)